### PR TITLE
Fix flatpak build issue

### DIFF
--- a/HelloTemplate/flatpak/my.example.HelloTemplate.json
+++ b/HelloTemplate/flatpak/my.example.HelloTemplate.json
@@ -7,7 +7,7 @@
         "org.freedesktop.Sdk.Extension.openjdk"
     ],
     "build-options" : {
-        "append-path": "/usr/lib/sdk/openjdk/gradle/bin:/app/jre/bin"
+        "append-path": "/usr/lib/sdk/openjdk/gradle/bin:/app/jdk/bin"
     },
     "command" : "/app/HelloTemplate/bin/my.example.HelloTemplate",
     "finish-args" : [
@@ -33,7 +33,7 @@
         {
             "name" : "my.example.HelloTemplate",
             "buildsystem" : "simple",
-            "build-commands" : [ "gradle installDist" ],
+            "build-commands" : [ "/usr/lib/sdk/openjdk/installjdk.sh", "gradle installDist" ],
             "sources" : [
                 { "type" : "dir", "path" : ".." },
                 "maven-dependencies.json"


### PR DESCRIPTION
This fixes the build issue on my side, due to no JDK (only a JRE) being installed for the build.

I'm not completely convinced the resulting flatpak is as small as needed, though: when I list the content of `~/.local/share/flatpak/app/my.example.HelloTemplate/current/active/files/HelloTemplate` after installing the flatpak, I see the following:

```
~/.local/share/flatpak/app/my.example.HelloTemplate/current/active/files$ tree -L 1
.
├── HelloTemplate
├── jdk
├── jre
└── manifest.json
```

Ideally, only the JRE should be shipped in the flatpak (it's all that's needed to run the app, afterall). The JDK is only needed when building the flatpak.